### PR TITLE
Correct page number - Update Week7.ipynb

### DIFF
--- a/Week7.ipynb
+++ b/Week7.ipynb
@@ -41,7 +41,7 @@
     {
       "cell_type": "markdown",
       "source": [
-        "## In Section 6.3, we consider change of basis _within_ one vector space. Refer to definition of page 485. I will offer an alternative definition below which I find easier to remember.\n",
+        "## In Section 6.3, we consider change of basis _within_ one vector space. Refer to definition of page 465. I will offer an alternative definition below which I find easier to remember.\n",
         "\n",
         "### Definition (change of basis matrix).\n",
         "Consider a vector space $V$, with two set of bases $B=\\{\\mathbf{u}_1,...,\\mathbf{u}_n\\}$ and $C=\\{\\mathbf{v}_1,...,\\mathbf{v}_n\\}$. Let $\\mathbf{x}$ be any vector in $V$. As $x$ can be represented by $B$ and $C$, we know\n",


### PR DESCRIPTION
Pg. 465, rather than 485, is the location of the definition of change-of-basis matrix in Poole, Lin Alg, 4th (2015).